### PR TITLE
Release 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: scala
 scala:
-   - 2.11.6
+   - 2.11.8
+   - 2.10.6
 script: sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-XX:MaxPermSize=1024M test

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ That if we add new field to class and try to read JSON written to KV storage wit
 )
 ```
 
-### @key annotation
+### `@key` annotation
 
 Pushka allows to define the key that a field is serialized with via a `@key` annotation
 
@@ -137,6 +137,19 @@ Pushka allows to define the key that a field is serialized with via a `@key` ann
 @pushka
 case class Log(@key("@ts") timestamp: String, message: String)
 ```
+
+### `@forceObject` annotation
+
+Case classes with one field writes without object wrapper by default. To avoid this behavior use `@forceObject` annotation.
+
+```scala
+@pushka case class Id(value: String)
+write(Id("9f3ce5")) // "9f3ce5"
+
+@pushka @forceObject case class Id(value: String) 
+write(Id("9f3ce5")) // { "value": "9f3ce5" }
+```
+
 ### `Map` writing
 
 Obviously `Map[K, V]` should be written as `{}` and this is true when `K` is `String`, `Int`, `Double` or `UUID`. But several `K` types can't be written as JSON object key. Consider `case class Point(x: Int, y: Int)`. This type will be written to JSON object. In this case `Map[Point, T]` will be written as sequence of tuples.

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,6 @@ val publishSettings = Seq(
 )
 
 val commonSettings = publishSettings ++ Seq(
-  scalaVersion := "2.11.8",
   organization := "com.github.fomkin",
   version := "0.5.0",
   libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0-M15" % "test",
@@ -48,7 +47,11 @@ lazy val core = crossProject.crossType(CrossType.Pure).
   settings(commonSettings: _*).
   settings(
     normalizedName := "pushka-core",
-    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "macro-compat" % "1.1.1",
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"
+    ),
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
     sourceGenerators in Compile <+= sourceManaged in Compile map GenTuples
   )
@@ -62,7 +65,7 @@ lazy val json = crossProject.crossType(CrossType.Full).
     normalizedName := "pushka-json",
     unmanagedSourceDirectories in Test += baseDirectory.value / ".." / "test-src"
   ).
-  jvmSettings(libraryDependencies += "org.spire-math" %% "jawn-parser" % "0.8.3").
+  jvmSettings(libraryDependencies += "org.spire-math" %% "jawn-parser" % "0.8.4").
   dependsOn(core)
 
 lazy val jsonJS = json.js
@@ -70,6 +73,6 @@ lazy val jsonJVM = json.jvm
 
 publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
 
-scalaVersion := "2.11.8"
+crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 publishArtifact := false

--- a/core/src/main/scala/pushka/DefaultObjectKeys.scala
+++ b/core/src/main/scala/pushka/DefaultObjectKeys.scala
@@ -1,0 +1,27 @@
+package pushka
+
+import java.util.UUID
+
+trait DefaultObjectKeys {
+
+  implicit val intOk = new ObjectKey[Int] {
+    def stringify(x: Int): String = x.toString
+    def parse(x: String): Int = x.toInt
+  }
+
+  implicit val doubleOk = new ObjectKey[Double] {
+    def stringify(x: Double): String = x.toString
+    def parse(x: String): Double = x.toDouble
+  }
+
+  implicit val stringToOK = new ObjectKey[String] {
+    def stringify(x: String): String = x
+    def parse(x: String): String = x
+  }
+
+  implicit val uuidToOK = new ObjectKey[UUID] {
+    def stringify(x: UUID): String = x.toString
+    def parse(x: String): UUID = UUID.fromString(x)
+  }
+
+}

--- a/core/src/main/scala/pushka/ObjectKey.scala
+++ b/core/src/main/scala/pushka/ObjectKey.scala
@@ -1,0 +1,6 @@
+package pushka
+
+trait ObjectKey[T] {
+  def stringify(x: T): String
+  def parse(x: String): T
+}

--- a/core/src/main/scala/pushka/annotation/forceObject.scala
+++ b/core/src/main/scala/pushka/annotation/forceObject.scala
@@ -1,0 +1,7 @@
+package pushka.annotation
+
+import scala.annotation.StaticAnnotation
+import scala.language.experimental.macros
+import scala.language.postfixOps
+
+class forceObject extends StaticAnnotation

--- a/core/src/main/scala/pushka/annotation/pushka.scala
+++ b/core/src/main/scala/pushka/annotation/pushka.scala
@@ -1,22 +1,26 @@
 package pushka.annotation
 
-import scala.annotation.{StaticAnnotation, tailrec}
 import scala.language.experimental.macros
 import scala.language.postfixOps
+
+import scala.annotation.{StaticAnnotation, tailrec}
 import scala.reflect.macros.blackbox
 
+import macrocompat.bundle
+
 class pushka extends StaticAnnotation {
-  def macroTransform(annottees: Any*): Any = macro pushkaMacro.impl
+  def macroTransform(annottees: Any*): Any =
+    macro PushkaAnnotatioMacro.impl
 }
 
 /**
  * @author Aleksey Fomkin <aleksey.fomkin@gmail.com>
  */
-object pushkaMacro {
+@bundle class PushkaAnnotatioMacro(val c: blackbox.Context) {
 
-  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+  import c.universe._
 
-    import c.universe._
+  def impl(annottees: c.Expr[Any]*): c.Expr[Any] = {
 
     def checkValDefIsOption(x: ValDef): Boolean = {
       x.tpt.children.headOption match {

--- a/core/src/main/scala/pushka/internal/Not.scala
+++ b/core/src/main/scala/pushka/internal/Not.scala
@@ -1,0 +1,10 @@
+package pushka.internal
+
+import scala.language.higherKinds
+
+final class Not[A](val x: Int) extends AnyVal
+
+object Not {
+  implicit def notA[A, TC[_]] = new Not[TC[A]](0)
+  implicit def notNotA[A : TC, TC[_]] = new Not[TC[A]](0)
+}

--- a/core/src/main/scala/pushka/package.scala
+++ b/core/src/main/scala/pushka/package.scala
@@ -1,4 +1,4 @@
-package object pushka extends DefaultRWs {
+package object pushka extends DefaultRWs with DefaultObjectKeys {
 
   object PushkaException {
 
@@ -19,7 +19,7 @@ package object pushka extends DefaultRWs {
     }
   }
 
-  case class PushkaException(message: String = "") extends Exception("")
+  case class PushkaException(message: String = "") extends Exception(message)
 
   trait RW[T] extends Reader[T] with Writer[T]
 

--- a/core/src/test/scala/CaseClassSpec.scala
+++ b/core/src/test/scala/CaseClassSpec.scala
@@ -10,6 +10,7 @@ object CaseClassSpec {
   @pushka case class Point[T](x: T, y: T)
   @pushka case class WithDefaultParams(x: Int, y: Int = 100)
   @pushka case class WithKeyAnnotation(@key("@theX") x: Int, y: Int)
+  @pushka @forceObject case class AppleReceipt(@key("receipt-data") receiptData: String)
 }
 
 class CaseClassSpec extends FlatSpec with Matchers {
@@ -167,5 +168,17 @@ class CaseClassSpec extends FlatSpec with Matchers {
       read[WithKeyAnnotation](invalidAst)
     }
     exception.message should be(s"Error while reading AST $invalidAst to WithKeyAnnotation")
+  }
+
+  "Case class annotated with @forceObject and having one field" should "be written as object" in {
+    val source = AppleReceipt("hello")
+    val pattern = Ast("receipt-data" -> "hello")
+    write(source) should be (pattern)
+  }
+
+  it should "be read from object" in {
+    val pattern = AppleReceipt("hello")
+    val source = Ast("receipt-data" -> "hello")
+    read[AppleReceipt](source) should be (pattern)
   }
 }

--- a/json/shared/src/main/scala/pushka/json/PushkaJsonBackend.scala
+++ b/json/shared/src/main/scala/pushka/json/PushkaJsonBackend.scala
@@ -2,7 +2,7 @@ package pushka.json
 
 import pushka._
 
-trait PushkaJsonBackend extends DefaultRWs {
+trait PushkaJsonBackend extends DefaultRWs with DefaultObjectKeys {
 
   def write[T](value: T)(implicit writer: Writer[T], printer: Printer[String]): String = {
     printer.print(writer.write(value))


### PR DESCRIPTION
Release notes:
- #31: Scala 2.10 support (PR #33)
- #30: Write `Map` as JSON object if possible (PR #32)
- #15: Allow to serialize case class with single field in js object (PR #34)
