### PR TITLE
Close #36: Support for Array[T]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val publishSettings = Seq(
 
 val commonSettings = publishSettings ++ Seq(
   organization := "com.github.fomkin",
-  version := "0.6.0",
+  version := "0.6.1",
   libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0-M15" % "test",
   scalacOptions ++= Seq(
     "-deprecation",

--- a/core/src/main/scala/pushka/DefaultRWs.scala
+++ b/core/src/main/scala/pushka/DefaultRWs.scala
@@ -1,8 +1,11 @@
 package pushka
 
 import java.util.UUID
+
 import scala.language.higherKinds
 import pushka.internal.Not
+
+import scala.reflect.ClassTag
 
 class DefaultRWs extends Generated {
 
@@ -144,6 +147,10 @@ class DefaultRWs extends Generated {
     def write(value: List[T]): Ast = writeIterable(value)
   }
 
+  implicit def arrayW[T](implicit w: Writer[T]): Writer[Array[T]] = new Writer[Array[T]] {
+    def write(value: Array[T]): Ast = writeIterable(value)
+  }
+
   implicit def mapW[K, V](implicit w: Writer[(K, V)], ev: Not[ObjectKey[K]]): Writer[Map[K, V]] = {
     new Writer[Map[K, V]] {
       def write(value: Map[K, V]): Ast = writeIterable(value)
@@ -185,6 +192,13 @@ class DefaultRWs extends Generated {
     def read(value: Ast): List[T] = value match {
       case Ast.Arr(xs) ⇒ xs.map(r.read).toList
       case _ ⇒ throw PushkaException(value, List.getClass)
+    }
+  }
+
+  implicit def arrayR[T](implicit r: Reader[T], classTag: ClassTag[T]): Reader[Array[T]] = new Reader[Array[T]] {
+    def read(value: Ast): Array[T] = value match {
+      case Ast.Arr(xs) ⇒ xs.map(r.read).toArray
+      case _ ⇒ throw PushkaException(value, Array.getClass)
     }
   }
 

--- a/core/src/test/scala/DefaultRWSpec.scala
+++ b/core/src/test/scala/DefaultRWSpec.scala
@@ -129,6 +129,24 @@ class DefaultRWSpec extends FlatSpec with Matchers {
     exception.message should be(s"Error while reading AST $invalidAst to Seq")
   }
 
+  "Array" should "be read from array" in {
+    val source = Ast.Arr(List(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
+    val pattern = Array(1, 2, 3)
+    read[Array[Int]](source) should be(pattern)
+  }
+  it should "be written to array" in {
+    val pattern = Ast.Arr(List(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
+    val source = Array(1, 2, 3)
+    write(source) should be(pattern)
+  }
+  it should "throw exception with correct message if Ast is invalid" in {
+    val invalidAst = Ast.Num(1)
+    val exception = intercept[PushkaException] {
+      read[Array[Int]](invalidAst)
+    }
+    exception.message should be(s"Error while reading AST $invalidAst to Array")
+  }
+
   "Map with arbitrary key" should "be written to array of kv pairs" in {
     val source = Map(ArbitaryKey(0) → "a", ArbitaryKey(1) → "b")
     val pattern = Ast.Arr(List(


### PR DESCRIPTION
Added support for `Array[T]`. Unfortunately, there is no way to create `Array[T]` without `ClassTag`. So, I was compelled to add `ClassTag` to reader definition.
