### PR TITLE
Scala Native support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ target/
 .project
 .settings/
 *.iml
+sbt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,27 @@ before_install:
   - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
   - sudo apt-get -qq update
-  - sudo apt-get install -y libgc-dev clang++-3.7 llvm-3.7 llvm-3.7-dev llvm-3.7-runtime llvm-3.7-tool libunwind7-dev
+  - |
+    sudo apt-get install -y \
+      clang++-3.7 \
+      llvm-3.7 \
+      llvm-3.7-dev \
+      llvm-3.7-runtime \
+      llvm-3.7-tool \
+      libgc-dev \
+      libunwind7-dev
+
+  # Install re2
+  # (libre2-dev) since Xenial (16.04 LTS) http://packages.ubuntu.com/xenial/libre2-dev
+  - sudo apt-get install -y make
+  - export CXX=clang++-3.7
+  - git clone https://code.googlesource.com/re2
+  - pushd re2
+  - git checkout 2017-03-01
+  - make -j4 test
+  - sudo make install prefix=/usr
+  - make testinstall prefix=/usr
+  - popd
 before_cache:
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,25 @@
-sudo: false
+sudo: required
 language: scala
 jdk:
   - oraclejdk8
 scala:
-  - 2.11.8
   - 2.10.6
-  - 2.12.0
-script: sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-XX:MaxPermSize=1024M test
+  - 2.11.8
+  - 2.12.1
+before_install:
+  - sudo apt-get -qq update
+  - sudo sh -c "echo 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main' >> /etc/apt/sources.list"
+  - sudo sh -c "echo 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main' >> /etc/apt/sources.list"
+  - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+  - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libgc-dev clang++-3.7 llvm-3.7 llvm-3.7-dev llvm-3.7-runtime llvm-3.7-tool libunwind7-dev
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
+cache:
+  directories:
+    - $HOME/.ivy2
+    - $HOME/.sbt
+script: .travis/test.sh

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-XX:MaxPermSize=1024M coreJVM/test
+sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-XX:MaxPermSize=1024M coreJS/test
+
+if [ "$TRAVIS_SCALA_VERSION" == "2.11.8" ]; then
+  sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-XX:MaxPermSize=1024M testNative/run
+fi

--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,6 @@ lazy val testNative = Project("testNative", file("test-native")).
 
 publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
 
-crossScalaVersions := Seq("2.11.8", "2.12.1")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1")
 
 publishArtifact := false

--- a/json/native/src/main/scala/pushka/json/JsonParser.scala
+++ b/json/native/src/main/scala/pushka/json/JsonParser.scala
@@ -7,7 +7,6 @@ import org.json4s.native._
 import org.json4s.native.JsonMethods
 
 final class JsonParser extends Parser[String] {
-
   private[this] def readAst(value: JValue): Ast = value match {
     case JInt(x) => Ast.Num(x.toString)
     case JDecimal(x) => Ast.Num(x.toString)

--- a/json/native/src/main/scala/pushka/json/JsonParser.scala
+++ b/json/native/src/main/scala/pushka/json/JsonParser.scala
@@ -3,7 +3,6 @@ package pushka.json
 import pushka.{Parser, PushkaException, Ast}
 
 import org.json4s._
-import org.json4s.native._
 import org.json4s.native.JsonMethods
 
 final class JsonParser extends Parser[String] {
@@ -17,9 +16,9 @@ final class JsonParser extends Parser[String] {
     case JString(s) => Ast.Str(s)
     case JNull => Ast.Null
     case JObject(v) => Ast.Obj(Map(v.map({ case JField(k, vl) => k -> readAst(vl)}):_*))
-    case JArray(items) => Ast.Arr(items.map(readAst(_)).toList)
-    case JSet(items) => Ast.Arr(items.map(readAst(_)).toList)
-    case JNothing => Ast.Null    
+    case JArray(items) => Ast.Arr(items.map(readAst))
+    case JSet(items) => Ast.Arr(items.map(readAst).toList)
+    case JNothing => throw new PushkaException(s"Term $value can't be converted to AST.")
   }
 
   def parse(data: String): Ast = readAst(JsonMethods.parse(data))

--- a/json/native/src/main/scala/pushka/json/JsonParser.scala
+++ b/json/native/src/main/scala/pushka/json/JsonParser.scala
@@ -1,0 +1,27 @@
+package pushka.json
+
+import pushka.{Parser, PushkaException, Ast}
+
+import org.json4s._
+import org.json4s.native._
+import org.json4s.native.JsonMethods
+
+final class JsonParser extends Parser[String] {
+
+  private[this] def readAst(value: JValue): Ast = value match {
+    case JInt(x) => Ast.Num(x.toString)
+    case JDecimal(x) => Ast.Num(x.toString)
+    case JDouble(x) => Ast.Num(x.toString)
+    case JLong(x) => Ast.Num(x.toString)
+    case JBool(true) => Ast.True
+    case JBool(false) => Ast.False
+    case JString(s) => Ast.Str(s)
+    case JNull => Ast.Null
+    case JObject(v) => Ast.Obj(Map(v.map({ case JField(k, vl) => k -> readAst(vl)}):_*))
+    case JArray(items) => Ast.Arr(items.map(readAst(_)).toList)
+    case JSet(items) => Ast.Arr(items.map(readAst(_)).toList)
+    case JNothing => Ast.Null    
+  }
+
+  def parse(data: String): Ast = readAst(JsonMethods.parse(data))
+}

--- a/json/native/src/main/scala/pushka/json/package.scala
+++ b/json/native/src/main/scala/pushka/json/package.scala
@@ -1,0 +1,9 @@
+package pushka
+
+import scala.language.implicitConversions
+
+package object json extends PushkaJsonBackend {
+
+  implicit val printer = new JsonPrinter()
+  implicit val parser = new JsonParser()
+}

--- a/json/native/src/main/scala/pushka/json/package.scala
+++ b/json/native/src/main/scala/pushka/json/package.scala
@@ -3,7 +3,6 @@ package pushka
 import scala.language.implicitConversions
 
 package object json extends PushkaJsonBackend {
-
   implicit val printer = new JsonPrinter()
   implicit val parser = new JsonParser()
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,4 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-native" % "sbt-crossproject"         % "0.1.0")
+addSbtPlugin("org.scala-native" % "sbt-scalajs-crossproject" % "0.1.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native"         % "0.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
 addSbtPlugin("org.scala-native" % "sbt-crossproject"         % "0.1.0")
 addSbtPlugin("org.scala-native" % "sbt-scalajs-crossproject" % "0.1.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native"         % "0.1.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native"         % "0.2.1")

--- a/test-native/src/main/scala/pushka/CaseClassSpec.scala
+++ b/test-native/src/main/scala/pushka/CaseClassSpec.scala
@@ -1,7 +1,5 @@
-package pushka 
+package pushka
 
-import pushka._
-import pushka.json._
 import pushka.annotation._
 
 // import scala.util.{Try, Success, Failure}
@@ -39,9 +37,9 @@ object CaseClassSpec {
       val invalidAst = Ast.Arr(Seq())
       val exception = Try { read[MyCaseClass](invalidAst) } 
       //exception.message should be(s"Error while reading AST $invalidAst to MyCaseClass")
-    }*/
+    }
 
-    /*{
+    {
       val invalidAst = Ast(
         "x" → pushka.Ast.Num(10),
         "z" → pushka.Ast.Str("vodka")

--- a/test-native/src/main/scala/pushka/CaseClassSpec.scala
+++ b/test-native/src/main/scala/pushka/CaseClassSpec.scala
@@ -2,17 +2,9 @@ package pushka
 
 import pushka.annotation._
 
-// import scala.util.{Try, Success, Failure}
+import scala.util.Try
 
-/**
- * Commented out test cases due to:
- * [error] cannot link: @java.util.regex.Pattern
- * [error] cannot link: @java.util.regex.Pattern$
- * [error] cannot link: @java.util.regex.Pattern$::compile_class.java.lang.String_class.java.util.regex.Pattern
- * [error] cannot link: @java.util.regex.Pattern::split_trait.java.lang.CharSequence_class.ssnr.ObjectArray
- * [error] unable to link
-*/
-object CaseClassSpec {
+object CaseClassSpec extends TestMethods {
   @pushka case class MyCaseClass(x: Int, y: Int, z: String)
   @pushka case class MyCaseClass2(x: Option[String], y: String)
   @pushka case class MyCaseClass3(x: (String, Double), y: String)
@@ -33,10 +25,10 @@ object CaseClassSpec {
       assert(write(instance) == pushka.Ast.Obj(m))
     }
 
-    /*{
+    {
       val invalidAst = Ast.Arr(Seq())
-      val exception = Try { read[MyCaseClass](invalidAst) } 
-      //exception.message should be(s"Error while reading AST $invalidAst to MyCaseClass")
+      val exception = Try { read[MyCaseClass](invalidAst) }
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to MyCaseClass")
     }
 
     {
@@ -45,24 +37,24 @@ object CaseClassSpec {
         "z" → pushka.Ast.Str("vodka")
       )
       val exception = Try { read[MyCaseClass](invalidAst) }
-      //exception.message should be(s"MyCaseClass should contain y")
-    }*/
+      exception.exceptionAssert("MyCaseClass should contain y")
+    }
 
     {
       val source = Id[String](10)
       assert(write[Id[String]](source) == Ast.Num(10))
     }
 
-    /*{
+    {
       val source = Ast.Num(10)
       assert(read[Id[String]](source) == Id[String](10))
-    }*/
+    }
 
-    /*{
+    {
       val invalidAst = Ast.True
       val exception = Try { read[Id[String]](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Int")
-    }*/
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Int")
+    }
 
     {
       val source = Point[Float](10, 10)
@@ -70,24 +62,24 @@ object CaseClassSpec {
       assert(write(source) == pattern)
     }
 
-    /*{
+    {
       val source = Ast("x" → 10.0, "y" → 10.0)
       val pattern = Point[Float](10, 10)
       assert(read[Point[Float]](source) == pattern)
-    }*/
+    }
 
-    /*{
+    {
       val invalidAst = Ast.Null
       val exception = Try { read[Point[Float]](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Point")
-    }*/
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Point")
+    }
 
     {
       val pattern = Ast.Obj(Map("y" → Ast.Str("vodka")))
       assert(write[MyCaseClass2](MyCaseClass2(None, "vodka")) == pattern)
     }
 
-    /*{
+    {
       val source = Ast.Obj(Map("y" → Ast.Str("vodka")))
       val pattern = MyCaseClass2(None, "vodka")
       assert(read[MyCaseClass2](source) == pattern)
@@ -102,8 +94,8 @@ object CaseClassSpec {
     {
       val invalidAst = Ast.Num(5)
       val exception = Try { read[MyCaseClass2](invalidAst) }
-      //exception.message should be(s"Error while reading AST $invalidAst to MyCaseClass2")
-    }*/
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to MyCaseClass2")
+    }
 
     {
       val pattern = Ast.Obj(Map(
@@ -116,7 +108,7 @@ object CaseClassSpec {
       assert(write(MyCaseClass3(("bear", 9d), "vodka")) == pattern)
     }
 
-    /*{
+    {
       val source = Ast.Obj(Map(
         "x" → Ast.Arr(Seq(
           Ast.Str("bear"),
@@ -137,7 +129,7 @@ object CaseClassSpec {
     {
       val invalidAst = Ast.False
       val exception = Try { read[WithDefaultParams](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to WithDefaultParams")
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to WithDefaultParams")
     }
 
     {
@@ -154,8 +146,8 @@ object CaseClassSpec {
     {
       val invalidAst = Ast.True
       val exception = Try { read[WithKeyAnnotation](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to WithKeyAnnotation")
-    }*/
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to WithKeyAnnotation")
+    }
 
     {
       val source = AppleReceipt("hello")
@@ -163,10 +155,10 @@ object CaseClassSpec {
       assert(write(source) == pattern)
     }
 
-    /*{
+    {
       val pattern = AppleReceipt("hello")
       val source = Ast("receipt-data" -> "hello")
       assert(read[AppleReceipt](source) == pattern)
-    }*/
+    }
   }  
 }

--- a/test-native/src/main/scala/pushka/CaseClassSpec.scala
+++ b/test-native/src/main/scala/pushka/CaseClassSpec.scala
@@ -1,0 +1,174 @@
+package pushka 
+
+import pushka._
+import pushka.json._
+import pushka.annotation._
+
+// import scala.util.{Try, Success, Failure}
+
+/**
+ * Commented out test cases due to:
+ * [error] cannot link: @java.util.regex.Pattern
+ * [error] cannot link: @java.util.regex.Pattern$
+ * [error] cannot link: @java.util.regex.Pattern$::compile_class.java.lang.String_class.java.util.regex.Pattern
+ * [error] cannot link: @java.util.regex.Pattern::split_trait.java.lang.CharSequence_class.ssnr.ObjectArray
+ * [error] unable to link
+*/
+object CaseClassSpec {
+  @pushka case class MyCaseClass(x: Int, y: Int, z: String)
+  @pushka case class MyCaseClass2(x: Option[String], y: String)
+  @pushka case class MyCaseClass3(x: (String, Double), y: String)
+  @pushka case class Id[+T](x: Int)
+  @pushka case class Point[T](x: T, y: T)
+  @pushka case class WithDefaultParams(x: Int, y: Int = 100, z: Option[Point[Int]] = Some(Point(1, 1)))
+  @pushka case class WithKeyAnnotation(@key("@theX") x: Int, y: Int)
+  @pushka @forceObject case class AppleReceipt(@key("receipt-data") receiptData: String)
+
+  def run: Unit = {
+    {
+      val instance = MyCaseClass(10, 10, "vodka")
+      val m = Map(
+        "x" → pushka.Ast.Num(10),
+        "y" → pushka.Ast.Num(10),
+        "z" → pushka.Ast.Str("vodka")
+      )
+      assert(write(instance) == pushka.Ast.Obj(m))
+    }
+
+    /*{
+      val invalidAst = Ast.Arr(Seq())
+      val exception = Try { read[MyCaseClass](invalidAst) } 
+      //exception.message should be(s"Error while reading AST $invalidAst to MyCaseClass")
+    }*/
+
+    /*{
+      val invalidAst = Ast(
+        "x" → pushka.Ast.Num(10),
+        "z" → pushka.Ast.Str("vodka")
+      )
+      val exception = Try { read[MyCaseClass](invalidAst) }
+      //exception.message should be(s"MyCaseClass should contain y")
+    }*/
+
+    {
+      val source = Id[String](10)
+      assert(write[Id[String]](source) == Ast.Num(10))
+    }
+
+    /*{
+      val source = Ast.Num(10)
+      assert(read[Id[String]](source) == Id[String](10))
+    }*/
+
+    /*{
+      val invalidAst = Ast.True
+      val exception = Try { read[Id[String]](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Int")
+    }*/
+
+    {
+      val source = Point[Float](10, 10)
+      val pattern = Ast("x" → 10.0, "y" → 10.0)
+      assert(write(source) == pattern)
+    }
+
+    /*{
+      val source = Ast("x" → 10.0, "y" → 10.0)
+      val pattern = Point[Float](10, 10)
+      assert(read[Point[Float]](source) == pattern)
+    }*/
+
+    /*{
+      val invalidAst = Ast.Null
+      val exception = Try { read[Point[Float]](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Point")
+    }*/
+
+    {
+      val pattern = Ast.Obj(Map("y" → Ast.Str("vodka")))
+      assert(write[MyCaseClass2](MyCaseClass2(None, "vodka")) == pattern)
+    }
+
+    /*{
+      val source = Ast.Obj(Map("y" → Ast.Str("vodka")))
+      val pattern = MyCaseClass2(None, "vodka")
+      assert(read[MyCaseClass2](source) == pattern)
+    }
+
+    {
+      val source = Ast.Obj(Map("x" → Ast.Null, "y" → Ast.Str("vodka")))
+      val pattern = MyCaseClass2(None, "vodka")
+      assert(read[MyCaseClass2](source) == pattern)
+    }
+
+    {
+      val invalidAst = Ast.Num(5)
+      val exception = Try { read[MyCaseClass2](invalidAst) }
+      //exception.message should be(s"Error while reading AST $invalidAst to MyCaseClass2")
+    }*/
+
+    {
+      val pattern = Ast.Obj(Map(
+        "x" → Ast.Arr(Seq(
+          Ast.Str("bear"),
+          Ast.Num(9d)
+        )),
+        "y" → Ast.Str("vodka"))
+      )
+      assert(write(MyCaseClass3(("bear", 9d), "vodka")) == pattern)
+    }
+
+    /*{
+      val source = Ast.Obj(Map(
+        "x" → Ast.Arr(Seq(
+          Ast.Str("bear"),
+          Ast.Num("9.0")
+        )),
+        "y" → Ast.Str("vodka"))
+      )
+      val pattern = MyCaseClass3(("bear", 9d), "vodka")
+      assert(read[MyCaseClass3](source) == pattern)
+    }
+
+    {
+      val source = Ast.Obj(Map("x" → Ast.Num(1)))
+      val pattern = WithDefaultParams(1, 100, Some(Point(1, 1)))
+      assert(read[WithDefaultParams](source) == pattern)
+    }
+
+    {
+      val invalidAst = Ast.False
+      val exception = Try { read[WithDefaultParams](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to WithDefaultParams")
+    }
+
+    {
+      val pattern = Ast.Obj(Map("@theX" → Ast.Num(1), "y" → Ast.Num(2)))
+      assert(write(WithKeyAnnotation(1, 2)) == pattern)
+    }
+
+    {
+      val source = Ast.Obj(Map("@theX" → Ast.Num(1), "y" → Ast.Num(2)))
+      val pattern = WithKeyAnnotation(1, 2)
+      assert(read[WithKeyAnnotation](source) == pattern)
+    }
+
+    {
+      val invalidAst = Ast.True
+      val exception = Try { read[WithKeyAnnotation](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to WithKeyAnnotation")
+    }*/
+
+    {
+      val source = AppleReceipt("hello")
+      val pattern = Ast("receipt-data" -> "hello")
+      assert(write(source) == pattern)
+    }
+
+    /*{
+      val pattern = AppleReceipt("hello")
+      val source = Ast("receipt-data" -> "hello")
+      assert(read[AppleReceipt](source) == pattern)
+    }*/
+  }  
+}

--- a/test-native/src/main/scala/pushka/DefaultRWSpec.scala
+++ b/test-native/src/main/scala/pushka/DefaultRWSpec.scala
@@ -1,8 +1,5 @@
 package pushka
 
-import pushka._
-import pushka.json._
-import pushka.annotation._
 import pushka.annotation.pushka
 
 // import scala.util.{Try, Success, Failure}

--- a/test-native/src/main/scala/pushka/DefaultRWSpec.scala
+++ b/test-native/src/main/scala/pushka/DefaultRWSpec.scala
@@ -2,19 +2,10 @@ package pushka
 
 import pushka.annotation.pushka
 
-// import scala.util.{Try, Success, Failure}
+import scala.util.Try
 import java.util.UUID
 
-/**
- * Commented out test cases due to:
- * [error] cannot link: @java.util.regex.Pattern
- * [error] cannot link: @java.util.regex.Pattern$
- * [error] cannot link: @java.util.regex.Pattern$::compile_class.java.lang.String_class.java.util.regex.Pattern
- * [error] cannot link: @java.util.regex.Pattern::split_trait.java.lang.CharSequence_class.ssnr.ObjectArray
- * [error] unable to link
-*/
-
-object DefaultRWSpec {
+object DefaultRWSpec extends TestMethods {
 
   @pushka case class Id[+T](value: Int)
 
@@ -26,80 +17,83 @@ object DefaultRWSpec {
   @pushka case class ArbitaryKey(x: Int)
 
   def run: Unit = {
-    /*{
+    {
       assert(read[Option[String]](Ast.Str("hello")) == Option("hello"))
-    }*/
-    // no implicit conversion here
-    /*{
-      assert(Option("hello") == Ast.Str("hello"))
-    }*/
+    }
+
     {
       assert(write(Option.empty[String]) == Ast.Null)
     }
-    /*{
+
+    {
       val invalidAst = Ast.True
       val exception = Try { read[Option[String]](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to String")
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to String")
     }
 
     {
       assert(read[Int](Ast.Num(42)) == 42)
-    }*/
+    }
+
     {
       assert(write(32) == Ast.Num(32))
     }
-    /*{
+
+    {
       val invalidAst = Ast.False
       val exception = Try { read[Int](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Int")
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Int")
     }
 
     {
       assert(read[Float](Ast.Num("42.0")) == 42.0f)
-    }*/
+    }
+
     {
       assert(write[Float](32.0f) == Ast.Num(32.0f))
     }
-    /*{
+
+    {
       val invalidAst = Ast.Null
       val exception = Try { read[Float](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Float")
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Float")
     }
 
     {
       assert(read[Double](Ast.Num("42.0")) == 42d)
-    }*/
+    }
+
     {
       assert(write[Double](32.0d) == Ast.Num(32.0d))
     }
-    /*{
+    {
       val invalidAst = Ast("foo" → "bar")
       val exception = Try { read[Double](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Double")
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Double")
     }
 
     {
       assert(read[Long](Ast.Num("609300804742756865")) == 609300804742756865l)
-    }*/
+    }
     {
       assert(write(609300804742756865l) == Ast.Num("609300804742756865"))
     }
-    /*{
+    {
       val invalidAst = Ast.Arr(Seq())
       val exception = Try { read[Long](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Long")
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Long")
     }
 
     {
       assert(read[UUID](Ast.Str("fff2a55d-afd6-44b9-ba3d-9f87685e6e50")) == UUID.fromString("fff2a55d-afd6-44b9-ba3d-9f87685e6e50"))     
-    }*/
+    }
     {
       assert(write(UUID.fromString("fff2a55d-afd6-44b9-ba3d-9f87685e6e50")) == Ast.Str("fff2a55d-afd6-44b9-ba3d-9f87685e6e50"))
     }
-    /*{
+    {
       val invalidAst = Ast.True
       val exception = Try { read[UUID](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to UUID")
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to UUID")
     }
 
     {
@@ -112,27 +106,29 @@ object DefaultRWSpec {
       val source = Seq(1, 2, 3)
       assert(write(source) == pattern)
     }
+
     {
       val invalidAst = Ast.Num(1)
       val exception = Try { read[Seq[Int]](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Seq")
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Seq")
     }
 
     {
       val source = Ast.Arr(List(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
       val pattern = Array(1, 2, 3)
-      assert(read[Array[Int]](source) == pattern)
-    }*/
+      assert(read[Array[Int]](source) sameElements pattern)
+    }
+
     {
       val pattern = Ast.Arr(List(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
       val source = Array(1, 2, 3)
       assert(write(source) == pattern)
     }
-    /*{
+    {
       val invalidAst = Ast.Num(1)
       val exception = Try { read[Array[Int]](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Array")
-    }*/
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Array")
+    }
 
     {
       val source = Map(ArbitaryKey(0) → "a", ArbitaryKey(1) → "b")
@@ -142,7 +138,7 @@ object DefaultRWSpec {
       ))
       assert(write(source) == pattern)
     }
-    /*{
+    {
       val pattern = Map(ArbitaryKey(0) → "a", ArbitaryKey(1) → "b")
       val source = Ast.Arr(List(
         Ast.Arr(List(Ast.Num(0), Ast.Str("a"))),
@@ -153,15 +149,16 @@ object DefaultRWSpec {
     {
       val invalidAst = Ast.Null
       val exception = Try { read[Map[ArbitaryKey, String]](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Map")
-    }*/
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Map")
+    }
 
     {
       val source = Map("0" → "a", "1" → "b")
       val pattern = Ast.Obj(Map("0" → Ast.Str("a"), "1" → Ast.Str("b")))
       assert(write(source) == pattern)
     }
-    /*{
+
+    {
       val pattern = Map(
         UUID.fromString("102b392e-862d-45e4-8140-35493598dff7") → "a",
         UUID.fromString("2c2fe2ce-1f6d-4cca-8ade-68a7bedc226f") → "b")
@@ -170,14 +167,15 @@ object DefaultRWSpec {
         "2c2fe2ce-1f6d-4cca-8ade-68a7bedc226f" → Ast.Str("b"))
       )
       assert(read[Map[UUID, String]](source) == pattern)
-    }*/
+    }
 
     {
       val source = Map(Id[ArbitaryKey](0) → "a", Id[ArbitaryKey](1) → "b")
       val pattern = Ast.Obj(Map("0" → Ast.Str("a"), "1" → Ast.Str("b")))
       assert(write(source) == pattern)
     }
-    /*{
+
+    {
       val pattern = Map(Id[ArbitaryKey](0) → "a", Id[ArbitaryKey](1) → "b")
       val source = Ast.Obj(Map("0" → Ast.Str("a"), "1" → Ast.Str("b")))
       assert(read[Map[Id[ArbitaryKey], String]](source) == pattern)
@@ -187,48 +185,54 @@ object DefaultRWSpec {
       val source = Ast.Arr(Vector(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
       val pattern = Set(1, 2, 3)
       assert(read[Set[Int]](source) == pattern)
-    }*/
+    }
+
     {
       val pattern = Ast.Arr(Vector(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
       val source = Set(1, 2, 3)
       assert(write(source) == pattern)
     }
-    /*{
+
+    {
       val invalidAst = Ast("bar" → "foo")
       val exception = Try { read[Set[Int]](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Set")
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Set")
     }
 
     {
       val source = Ast.Obj(Map("left" → Ast.Str("hello")))
       val pattern = Left("hello")
       assert(read[Either[String, Int]](source) == pattern)
-    }*/
+    }
+
     {
       val source = Left("hello")
       val pattern = Ast.Obj(Map("left" → Ast.Str("hello")))
       assert(write[Either[String, Int]](source) == pattern)
     }
-    /*{
+
+    {
       val invalidAst = Ast.Arr(Seq())
       val exception = Try { read[Either[String, Int]](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Either")
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Either")
     }
 
     {
       val source = Ast.Obj(Map("right" → Ast.Num(20)))
       val pattern = Right(20)
       assert(read[Either[String, Int]](source) == pattern)
-    }*/
+    }
+
     {
       val source = Right(20)
       val pattern = Ast.Obj(Map("right" → Ast.Num(20)))
       assert(write[Either[String, Int]](source) == pattern)
     }
-    /*{
+
+    {
       val invalidAst = Ast.False
       val exception = Try { read[Either[String, Int]](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Either")
-    }*/
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Either")
+    }
   }
 }

--- a/test-native/src/main/scala/pushka/DefaultRWSpec.scala
+++ b/test-native/src/main/scala/pushka/DefaultRWSpec.scala
@@ -1,0 +1,237 @@
+package pushka
+
+import pushka._
+import pushka.json._
+import pushka.annotation._
+import pushka.annotation.pushka
+
+// import scala.util.{Try, Success, Failure}
+import java.util.UUID
+
+/**
+ * Commented out test cases due to:
+ * [error] cannot link: @java.util.regex.Pattern
+ * [error] cannot link: @java.util.regex.Pattern$
+ * [error] cannot link: @java.util.regex.Pattern$::compile_class.java.lang.String_class.java.util.regex.Pattern
+ * [error] cannot link: @java.util.regex.Pattern::split_trait.java.lang.CharSequence_class.ssnr.ObjectArray
+ * [error] unable to link
+*/
+
+object DefaultRWSpec {
+
+  @pushka case class Id[+T](value: Int)
+
+  implicit def idOk[T] = new ObjectKey[Id[T]] {
+    def stringify(x: Id[T]): String = x.value.toString
+    def parse(x: String): Id[T] = Id(x.toInt)
+  }
+
+  @pushka case class ArbitaryKey(x: Int)
+
+  def run: Unit = {
+    /*{
+      assert(read[Option[String]](Ast.Str("hello")) == Option("hello"))
+    }*/
+    // no implicit conversion here
+    /*{
+      assert(Option("hello") == Ast.Str("hello"))
+    }*/
+    {
+      assert(write(Option.empty[String]) == Ast.Null)
+    }
+    /*{
+      val invalidAst = Ast.True
+      val exception = Try { read[Option[String]](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to String")
+    }
+
+    {
+      assert(read[Int](Ast.Num(42)) == 42)
+    }*/
+    {
+      assert(write(32) == Ast.Num(32))
+    }
+    /*{
+      val invalidAst = Ast.False
+      val exception = Try { read[Int](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Int")
+    }
+
+    {
+      assert(read[Float](Ast.Num("42.0")) == 42.0f)
+    }*/
+    {
+      assert(write[Float](32.0f) == Ast.Num(32.0f))
+    }
+    /*{
+      val invalidAst = Ast.Null
+      val exception = Try { read[Float](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Float")
+    }
+
+    {
+      assert(read[Double](Ast.Num("42.0")) == 42d)
+    }*/
+    {
+      assert(write[Double](32.0d) == Ast.Num(32.0d))
+    }
+    /*{
+      val invalidAst = Ast("foo" → "bar")
+      val exception = Try { read[Double](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Double")
+    }
+
+    {
+      assert(read[Long](Ast.Num("609300804742756865")) == 609300804742756865l)
+    }*/
+    {
+      assert(write(609300804742756865l) == Ast.Num("609300804742756865"))
+    }
+    /*{
+      val invalidAst = Ast.Arr(Seq())
+      val exception = Try { read[Long](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Long")
+    }
+
+    {
+      assert(read[UUID](Ast.Str("fff2a55d-afd6-44b9-ba3d-9f87685e6e50")) == UUID.fromString("fff2a55d-afd6-44b9-ba3d-9f87685e6e50"))     
+    }*/
+    {
+      assert(write(UUID.fromString("fff2a55d-afd6-44b9-ba3d-9f87685e6e50")) == Ast.Str("fff2a55d-afd6-44b9-ba3d-9f87685e6e50"))
+    }
+    /*{
+      val invalidAst = Ast.True
+      val exception = Try { read[UUID](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to UUID")
+    }
+
+    {
+      val source = Ast.Arr(List(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
+      val pattern = Seq(1, 2, 3)
+      assert(read[Seq[Int]](source) == pattern)
+    }
+    {
+      val pattern = Ast.Arr(List(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
+      val source = Seq(1, 2, 3)
+      assert(write(source) == pattern)
+    }
+    {
+      val invalidAst = Ast.Num(1)
+      val exception = Try { read[Seq[Int]](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Seq")
+    }
+
+    {
+      val source = Ast.Arr(List(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
+      val pattern = Array(1, 2, 3)
+      assert(read[Array[Int]](source) == pattern)
+    }*/
+    {
+      val pattern = Ast.Arr(List(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
+      val source = Array(1, 2, 3)
+      assert(write(source) == pattern)
+    }
+    /*{
+      val invalidAst = Ast.Num(1)
+      val exception = Try { read[Array[Int]](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Array")
+    }*/
+
+    {
+      val source = Map(ArbitaryKey(0) → "a", ArbitaryKey(1) → "b")
+      val pattern = Ast.Arr(List(
+        Ast.Arr(List(Ast.Num(0), Ast.Str("a"))),
+        Ast.Arr(List(Ast.Num(1), Ast.Str("b")))
+      ))
+      assert(write(source) == pattern)
+    }
+    /*{
+      val pattern = Map(ArbitaryKey(0) → "a", ArbitaryKey(1) → "b")
+      val source = Ast.Arr(List(
+        Ast.Arr(List(Ast.Num(0), Ast.Str("a"))),
+        Ast.Arr(List(Ast.Num(1), Ast.Str("b")))
+      ))
+      assert(read[Map[ArbitaryKey, String]](source) == pattern)
+    }
+    {
+      val invalidAst = Ast.Null
+      val exception = Try { read[Map[ArbitaryKey, String]](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Map")
+    }*/
+
+    {
+      val source = Map("0" → "a", "1" → "b")
+      val pattern = Ast.Obj(Map("0" → Ast.Str("a"), "1" → Ast.Str("b")))
+      assert(write(source) == pattern)
+    }
+    /*{
+      val pattern = Map(
+        UUID.fromString("102b392e-862d-45e4-8140-35493598dff7") → "a",
+        UUID.fromString("2c2fe2ce-1f6d-4cca-8ade-68a7bedc226f") → "b")
+      val source = Ast.Obj(Map(
+        "102b392e-862d-45e4-8140-35493598dff7" → Ast.Str("a"),
+        "2c2fe2ce-1f6d-4cca-8ade-68a7bedc226f" → Ast.Str("b"))
+      )
+      assert(read[Map[UUID, String]](source) == pattern)
+    }*/
+
+    {
+      val source = Map(Id[ArbitaryKey](0) → "a", Id[ArbitaryKey](1) → "b")
+      val pattern = Ast.Obj(Map("0" → Ast.Str("a"), "1" → Ast.Str("b")))
+      assert(write(source) == pattern)
+    }
+    /*{
+      val pattern = Map(Id[ArbitaryKey](0) → "a", Id[ArbitaryKey](1) → "b")
+      val source = Ast.Obj(Map("0" → Ast.Str("a"), "1" → Ast.Str("b")))
+      assert(read[Map[Id[ArbitaryKey], String]](source) == pattern)
+    }
+
+    {
+      val source = Ast.Arr(Vector(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
+      val pattern = Set(1, 2, 3)
+      assert(read[Set[Int]](source) == pattern)
+    }*/
+    {
+      val pattern = Ast.Arr(Vector(Ast.Num(1), Ast.Num(2), Ast.Num(3)))
+      val source = Set(1, 2, 3)
+      assert(write(source) == pattern)
+    }
+    /*{
+      val invalidAst = Ast("bar" → "foo")
+      val exception = Try { read[Set[Int]](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Set")
+    }
+
+    {
+      val source = Ast.Obj(Map("left" → Ast.Str("hello")))
+      val pattern = Left("hello")
+      assert(read[Either[String, Int]](source) == pattern)
+    }*/
+    {
+      val source = Left("hello")
+      val pattern = Ast.Obj(Map("left" → Ast.Str("hello")))
+      assert(write[Either[String, Int]](source) == pattern)
+    }
+    /*{
+      val invalidAst = Ast.Arr(Seq())
+      val exception = Try { read[Either[String, Int]](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Either")
+    }
+
+    {
+      val source = Ast.Obj(Map("right" → Ast.Num(20)))
+      val pattern = Right(20)
+      assert(read[Either[String, Int]](source) == pattern)
+    }*/
+    {
+      val source = Right(20)
+      val pattern = Ast.Obj(Map("right" → Ast.Num(20)))
+      assert(write[Either[String, Int]](source) == pattern)
+    }
+    /*{
+      val invalidAst = Ast.False
+      val exception = Try { read[Either[String, Int]](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Either")
+    }*/
+  }
+}

--- a/test-native/src/main/scala/pushka/Main.scala
+++ b/test-native/src/main/scala/pushka/Main.scala
@@ -1,0 +1,9 @@
+package pushka
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    CaseClassSpec.run
+    SealedTraitSpec.run
+    DefaultRWSpec.run
+  }
+}

--- a/test-native/src/main/scala/pushka/SealedTraitSpec.scala
+++ b/test-native/src/main/scala/pushka/SealedTraitSpec.scala
@@ -1,0 +1,107 @@
+package pushka
+
+import pushka._
+import pushka.json._
+import pushka.annotation._
+
+// import scala.util.{Try, Success, Failure}
+import scala.annotation.StaticAnnotation
+
+/**
+ * Commented out test cases due to:
+ * [error] cannot link: @java.util.regex.Pattern
+ * [error] cannot link: @java.util.regex.Pattern$
+ * [error] cannot link: @java.util.regex.Pattern$::compile_class.java.lang.String_class.java.util.regex.Pattern
+ * [error] cannot link: @java.util.regex.Pattern::split_trait.java.lang.CharSequence_class.ssnr.ObjectArray
+ * [error] unable to link
+*/
+object SealedTraitSpec {
+
+  abstract class Rgb(r: Int, g: Int, b: Int)
+
+  @pushka sealed trait Color
+
+  object Color {
+    case object Red extends Rgb(255, 0, 0) with Color
+    case object Green extends Rgb(0, 255, 0) with Color
+    case object Blue extends Rgb(0, 0, 255) with Color
+  }
+
+  @pushka sealed trait WithBody {
+    def x: Int
+  }
+
+  object WithBody {
+    case object A extends WithBody { val x = 0 }
+    case class B(y: Int) extends WithBody { val x = 1 }
+  }
+
+  @pushka sealed trait User
+
+  object User {
+    case object Empty extends User
+    case class Name(first: String, last: String) extends User
+    case object Anonymous extends User
+  }
+
+  @pushka case class Container(user: User, anotherField: Int)
+
+  class theAnnotation(a: String, b: String) extends StaticAnnotation
+
+  @pushka sealed trait Base
+
+  object Base {
+    @theAnnotation("Some message", "Today")
+    case class Descendant(value: Int) extends Base
+
+    object Descendant {
+      def haha(): Unit = {}
+    }
+  }
+
+  def run: Unit = {
+    {
+      val instance = Container(User.Name("John", "Doe"), 10)
+      assert(write(instance) == 
+        Ast.Obj(Map(
+          "user" → Ast.Obj(Map(
+            "name" → Ast.Obj(Map(
+              "first" → Ast.Str("John"),
+              "last" → Ast.Str("Doe"))
+            ))),
+          "anotherField" → Ast.Num("10")
+        ))
+      )
+    }
+
+    {
+      val instance = Container(User.Empty, 10)
+      assert(write(instance) == 
+        Ast.Obj(Map(
+          "user" → Ast.Str("empty"),
+          "anotherField" → Ast.Num("10"
+          ))
+        )
+      )
+    }
+
+    {
+      assert(write[WithBody](WithBody.A) == Ast.Str("a"))
+      assert(write[WithBody](WithBody.B(1)) == Ast.Obj(Map("b" → Ast.Num(1))))
+    }
+
+    {
+      write[Base](Base.Descendant(42))
+    }
+
+    /*{
+      assert(read[Color](Ast.Str("red")) == Color.Red)
+    }
+
+    {
+      val invalidAst = Ast("foo" → "bar")
+      val exception = Try { read[Color](invalidAst) }
+      // exception.message should be(s"Error while reading AST $invalidAst to Color")
+    }*/
+  }
+}

--- a/test-native/src/main/scala/pushka/SealedTraitSpec.scala
+++ b/test-native/src/main/scala/pushka/SealedTraitSpec.scala
@@ -1,7 +1,5 @@
 package pushka
 
-import pushka._
-import pushka.json._
 import pushka.annotation._
 
 // import scala.util.{Try, Success, Failure}

--- a/test-native/src/main/scala/pushka/SealedTraitSpec.scala
+++ b/test-native/src/main/scala/pushka/SealedTraitSpec.scala
@@ -2,18 +2,10 @@ package pushka
 
 import pushka.annotation._
 
-// import scala.util.{Try, Success, Failure}
+import scala.util.Try
 import scala.annotation.StaticAnnotation
 
-/**
- * Commented out test cases due to:
- * [error] cannot link: @java.util.regex.Pattern
- * [error] cannot link: @java.util.regex.Pattern$
- * [error] cannot link: @java.util.regex.Pattern$::compile_class.java.lang.String_class.java.util.regex.Pattern
- * [error] cannot link: @java.util.regex.Pattern::split_trait.java.lang.CharSequence_class.ssnr.ObjectArray
- * [error] unable to link
-*/
-object SealedTraitSpec {
+object SealedTraitSpec extends TestMethods {
 
   abstract class Rgb(r: Int, g: Int, b: Int)
 
@@ -92,14 +84,14 @@ object SealedTraitSpec {
       write[Base](Base.Descendant(42))
     }
 
-    /*{
+    {
       assert(read[Color](Ast.Str("red")) == Color.Red)
     }
 
     {
       val invalidAst = Ast("foo" → "bar")
       val exception = Try { read[Color](invalidAst) }
-      // exception.message should be(s"Error while reading AST $invalidAst to Color")
-    }*/
+      exception.exceptionAssert(s"Error while reading AST $invalidAst to Color")
+    }
   }
 }

--- a/test-native/src/main/scala/pushka/TestMethods.scala
+++ b/test-native/src/main/scala/pushka/TestMethods.scala
@@ -1,0 +1,15 @@
+package pushka
+
+import scala.util.{Failure, Success, Try}
+
+trait TestMethods {
+  implicit class tryAssertionMethods[T](th: Try[T]) {
+    def exceptionAssert(str: String): Unit = {
+      th match {
+        case Success(_) => throw new Exception ("PushkaException should be thrown.")
+        case Failure(e: PushkaException) => assert(e.message == str)
+        case Failure(e) => throw e
+      }
+    }
+  }
+}


### PR DESCRIPTION
Experimental Scala Native support requires Scala 2.11; sn has no sbt tests support, here is provided a workaround. 

- [x] fix commented out test cases
- [x] ci

~~Blocked by https://github.com/scala-native/scala-native/issues/571~~
